### PR TITLE
Fix Tenant status update issue.

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -545,7 +545,8 @@ public class OrganizationManagerImpl implements OrganizationManager {
 
         if (StringUtils.equals(ACTIVE.toString(), status)) {
             try {
-                getTenantMgtService().activateTenant(getRealmService().getTenantManager().getTenantId(organizationId));
+                String tenantDomain = organizationManagementDAO.resolveTenantDomain(organizationId);
+                getTenantMgtService().activateTenant(getRealmService().getTenantManager().getTenantId(tenantDomain));
             } catch (TenantMgtException | UserStoreException e) {
                 throw handleServerException(ERROR_CODE_ERROR_ACTIVATING_ORGANIZATION_TENANT, e, organizationId);
             }


### PR DESCRIPTION
## Purpose
> When updating the organizations, if the organization status is "ACTIVE", the respective tenant will be activated. In order to load the tenant, relying on organization-id is incorrect. The organization-id should be converted to tenant-domain first of all.