### PR TITLE
Remove unnecessary requestInvokingOrganizationId null check in sub org handling

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -221,9 +221,6 @@ public class OrganizationManagerImpl implements OrganizationManager {
             throw handleClientException(ERROR_CODE_ORGANIZATION_ID_UNDEFINED);
         }
         String requestInvokingOrganizationId = getOrganizationId();
-        if (requestInvokingOrganizationId == null) {
-            requestInvokingOrganizationId = SUPER_ORG_ID;
-        }
         validateOrganizationAccess(requestInvokingOrganizationId, organizationId, true);
         getListener().preGetOrganization(organizationId.trim());
 
@@ -337,9 +334,6 @@ public class OrganizationManagerImpl implements OrganizationManager {
             throw handleClientException(ERROR_CODE_ORGANIZATION_ID_UNDEFINED);
         }
         String requestInvokingOrganizationId = getOrganizationId();
-        if (requestInvokingOrganizationId == null) {
-            requestInvokingOrganizationId = SUPER_ORG_ID;
-        }
         validateOrganizationAccess(requestInvokingOrganizationId, organizationId, false);
         validateOrganizationDelete(organizationId);
         Organization organization = organizationManagementDAO.getOrganization(organizationId);
@@ -371,9 +365,6 @@ public class OrganizationManagerImpl implements OrganizationManager {
         }
         organizationId = organizationId.trim();
         String requestInvokingOrganizationId = getOrganizationId();
-        if (requestInvokingOrganizationId == null) {
-            requestInvokingOrganizationId = SUPER_ORG_ID;
-        }
         validateOrganizationAccess(requestInvokingOrganizationId, organizationId, false);
         if (!isOrganizationExistById(organizationId)) {
             throw handleClientException(ERROR_CODE_INVALID_ORGANIZATION, organizationId);
@@ -403,9 +394,6 @@ public class OrganizationManagerImpl implements OrganizationManager {
         }
         organizationId = organizationId.trim();
         String requestInvokingOrganizationId = getOrganizationId();
-        if (requestInvokingOrganizationId == null) {
-            requestInvokingOrganizationId = SUPER_ORG_ID;
-        }
         validateOrganizationAccess(requestInvokingOrganizationId, organizationId, false);
         if (!isOrganizationExistById(organizationId)) {
             throw handleClientException(ERROR_CODE_INVALID_ORGANIZATION, organizationId);


### PR DESCRIPTION
### Purpose
> This fixes the unnecessary requestInvokingOrganizationId null check which causes issues in sub-organisation CRUD operations in tenant-qualified paths. With the following PR [1] organization ID will be returned even if it is a tenanted path as opposed to earlier functionality. If the organization ID couldn't be retrieved, a RuntimeException will be thrown. 

### Related PRs
- [1] https://github.com/wso2/identity-organization-management-core/pull/103 