### PR TITLE
Remove the deprecated organization permission check when resolving the user from the organization hierarchy.

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
@@ -97,7 +97,8 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
                                 domain = secondaryUserStoreManager.getRealmConfiguration().getUserStoreProperties()
                                         .get(PROPERTY_DOMAIN_NAME);
                                 if (userStoreManager.isExistingUser(domain + DOMAIN_SEPARATOR + userName)) {
-                                    return Optional.of(userStoreManager.getUser(null, domain + DOMAIN_SEPARATOR + userName));
+                                    return Optional.of(
+                                            userStoreManager.getUser(null, domain + DOMAIN_SEPARATOR + userName));
                                 }
                                 secondaryUserStoreManager = secondaryUserStoreManager.getSecondaryUserStoreManager();
                             }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
@@ -40,7 +40,6 @@ import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.Permission;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
-import org.wso2.carbon.user.core.common.User;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.user.mgt.UserMgtConstants;
@@ -227,16 +226,18 @@ public class Utils {
      */
     public static String getAuthenticatedUsername() {
 
-        String username = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
-        if (username == null) {
+        String userResidentOrganizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .getUserResidentOrganizationId();
+        /* When user accessing a different organization, the user resident organization is populated in the carbon
+            context. That value can be used to find the username from the user ID. */
+        if (StringUtils.isNotEmpty(userResidentOrganizationId)) {
             try {
-                username = organizationUserResidentResolverService.resolveUserFromResidentOrganization(null,
-                        getUserId(), getOrganizationId()).map(User::getUsername).orElse(null);
-            } catch (OrganizationManagementException e) {
+                return getUserStoreManager(userResidentOrganizationId).getUser(getUserId(), null).getUsername();
+            } catch (OrganizationManagementException | UserStoreException e) {
                 LOG.debug("Authenticated user's username could not be resolved.", e);
             }
         }
-        return username;
+        return PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
     }
 
     /**
@@ -246,22 +247,7 @@ public class Utils {
      */
     public static String getUserId() {
 
-        String userId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserId();
-        /*
-            The federated users with organization management permissions do not have user id set in the carbon
-            context but the user id is set against the username. Therefore the user is resolved by the user id
-            information saved in the username.
-         */
-        if (userId == null && PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername() != null) {
-            try {
-                userId = organizationUserResidentResolverService.resolveUserFromResidentOrganization(null,
-                        PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername(),
-                        getOrganizationId()).map(User::getUserID).orElse(null);
-            } catch (OrganizationManagementException e) {
-                LOG.debug("Authenticated user's id could not be resolved.", e);
-            }
-        }
-        return userId;
+        return PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserId();
     }
 
     /**
@@ -646,5 +632,17 @@ public class Utils {
 
         UUID uuid = UUID.randomUUID();
         return uuid.toString().substring(0, 12);
+    }
+
+    private static AbstractUserStoreManager getUserStoreManager(String organizationId)
+            throws UserStoreException, OrganizationManagementException {
+
+        String tenantDomain = OrganizationManagementDataHolder.getInstance().getOrganizationManager()
+                .resolveTenantDomain(organizationId);
+        int tenantId = OrganizationManagementDataHolder.getInstance().getRealmService().getTenantManager()
+                .getTenantId(tenantDomain);
+        RealmService realmService = OrganizationManagementDataHolder.getInstance().getRealmService();
+        UserRealm tenantUserRealm = realmService.getTenantUserRealm(tenantId);
+        return (AbstractUserStoreManager) tenantUserRealm.getUserStoreManager();
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.Permission;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.common.User;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.user.mgt.UserMgtConstants;
@@ -232,7 +233,10 @@ public class Utils {
             context. That value can be used to find the username from the user ID. */
         if (StringUtils.isNotEmpty(userResidentOrganizationId)) {
             try {
-                return getUserStoreManager(userResidentOrganizationId).getUser(getUserId(), null).getUsername();
+                 User user = getUserStoreManager(userResidentOrganizationId).getUser(getUserId(), null);
+                 if (user != null) {
+                     return user.getUsername();
+                 }
             } catch (OrganizationManagementException | UserStoreException e) {
                 LOG.debug("Authenticated user's username could not be resolved.", e);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
     <properties>
 
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.9.0-m1</carbon.kernel.version>
+        <carbon.kernel.version>4.9.17</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.7.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
 


### PR DESCRIPTION
## Purpose
> $subject

### Related Issues
- https://github.com/wso2/product-is/issues/17520

This PR contains two efforts
- Remove the check for permissions of user against organization when resolving the user from the hierarchy. 
- Improve the user ID and user name resolving utils.  