### PR TITLE
Remove the service URL builds at organization core level

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -132,7 +132,6 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.SUPER;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.SUPER_ORG_ID;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.SW;
-import static org.wso2.carbon.identity.organization.management.service.util.Utils.buildURIForBody;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.getAuthenticatedUsername;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.getOrganizationId;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.getTenantDomain;
@@ -229,10 +228,6 @@ public class OrganizationManagerImpl implements OrganizationManager {
             throw handleClientException(ERROR_CODE_INVALID_ORGANIZATION, organizationId);
         }
 
-        if (!SUPER.equals(organization.getName())) {
-            organization.getParent().setRef(buildURIForBody(organization.getParent().getId()));
-        }
-
         if (showChildren) {
             List<String> childOrganizationIds = organizationManagementDAO.getChildOrganizationIds(organizationId);
             if (CollectionUtils.isNotEmpty(childOrganizationIds)) {
@@ -240,7 +235,6 @@ public class OrganizationManagerImpl implements OrganizationManager {
                 for (String childOrganizationId : childOrganizationIds) {
                     ChildOrganizationDO childOrganization = new ChildOrganizationDO();
                     childOrganization.setId(childOrganizationId);
-                    childOrganization.setRef(buildURIForBody(childOrganizationId));
                     childOrganizations.add(childOrganization);
                 }
                 organization.setChildOrganizations(childOrganizations);
@@ -377,12 +371,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
 
         getListener().postPatchOrganization(organizationId, patchOperations);
 
-        Organization organization = organizationManagementDAO.getOrganization(organizationId);
-        if (!SUPER.equals(organization.getName())) {
-            organization.getParent().setRef(buildURIForBody(organization.getParent().getId()));
-        }
-
-        return organization;
+        return organizationManagementDAO.getOrganization(organizationId);
     }
 
     @Override
@@ -410,9 +399,6 @@ public class OrganizationManagerImpl implements OrganizationManager {
         organizationManagementDAO.updateOrganization(organizationId, organization);
 
         Organization updatedOrganization = organizationManagementDAO.getOrganization(organizationId);
-        if (!SUPER.equals(updatedOrganization.getName())) {
-            updatedOrganization.getParent().setRef(buildURIForBody(updatedOrganization.getParent().getId()));
-        }
 
         if (StringUtils.equals(TENANT.toString(), organization.getType())) {
             updateTenantStatus(organization.getStatus(), organizationId);
@@ -726,7 +712,6 @@ public class OrganizationManagerImpl implements OrganizationManager {
 
         validateAddOrganizationParentStatus(parentId);
         parentOrganization.setId(parentId);
-        parentOrganization.setRef(buildURIForBody(parentId));
     }
 
     private void validateUpdateOrganizationRequest(String currentOrganizationName, Organization organization)

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
@@ -59,12 +59,8 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_CREATING_NEW_SYSTEM_ROLE;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.IS_CARBON_ROLE_VALIDATION_ENABLED_FOR_LEVEL_ONE_ORGS;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.IS_ORG_QUALIFIED_URLS_SUPPORTED_FOR_LEVEL_ONE_ORGS;
-import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ORGANIZATION_CONTEXT_PATH_COMPONENT;
-import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ORGANIZATION_PATH;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATH_SEPARATOR;
-import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.SERVER_API_PATH_COMPONENT;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.SUB_ORG_START_LEVEL;
-import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.V1_API_PATH_COMPONENT;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.MICROSOFT;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.MYSQL;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.ORACLE;
@@ -252,36 +248,6 @@ public class Utils {
     public static String getUserId() {
 
         return PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserId();
-    }
-
-    /**
-     * Build URI prepending the server API context with the proxy context path to the endpoint.
-     *
-     * @param organizationId The organization ID.
-     * @return Relative URI.
-     */
-    public static String buildURIForBody(String organizationId) {
-
-        String context = getContext(V1_API_PATH_COMPONENT + PATH_SEPARATOR + ORGANIZATION_PATH
-                + PATH_SEPARATOR + organizationId);
-
-        return context;
-    }
-
-    /**
-     * Builds the API context.
-     *
-     * @param endpoint Relative endpoint path.
-     * @return Context of the API.
-     */
-    public static String getContext(String endpoint) {
-
-        String organizationId = getOrganizationId();
-        if (StringUtils.isNotBlank(organizationId)) {
-            return String.format(ORGANIZATION_CONTEXT_PATH_COMPONENT, organizationId) + SERVER_API_PATH_COMPONENT +
-                    endpoint;
-        }
-        return SERVER_API_PATH_COMPONENT + endpoint;
     }
 
     /**


### PR DESCRIPTION
## Purpose
>  The service URL resource links can be build at the controller layer (api-server repo). Hence the service URL building logics in the service layer methods can be removed.

### Related Issues
- https://github.com/wso2/product-is/issues/17606