### PR TITLE
Add check to create the self-service user for legacy authz runtime

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.service/pom.xml
@@ -36,6 +36,17 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.utils</artifactId>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.utils</groupId>
             <artifactId>org.wso2.carbon.database.utils</artifactId>
             <scope>provided</scope>

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -123,6 +123,10 @@ public class OrganizationManagementConstants {
     public static final String SELF_SERVICE_INTERNAL_ROLE_PERMISSIONS =
             "SelfService.InternalRolePermissions.Permission";
 
+    // Application sharing related constants
+    public static final String SHARE_WITH_ALL_CHILDREN = "shareWithAllChildren";
+    public static final String IS_APP_SHARED = "isAppShared";
+
     /**
      * Contains constants related to filter operations.
      */

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.database.utils.jdbc.NamedJdbcTemplate;
 import org.wso2.carbon.database.utils.jdbc.exceptions.DataAccessException;
@@ -447,6 +448,10 @@ public class Utils {
      */
     public static String getB2BSelfServiceSystemUser(String tenantDomain) {
 
+        // If Legacy authorization is not enabled, API subscription will be used and there's no need to crete this user.
+        if (!isLegacyAuthzRuntime()) {
+            return null;
+        }
         // Read self service configurations.
         String userName = OrganizationManagementConfigUtil.getProperty(
                 OrganizationManagementConstants.SELF_SERVICE_SYSTEM_USER_NAME);
@@ -614,5 +619,15 @@ public class Utils {
         RealmService realmService = OrganizationManagementDataHolder.getInstance().getRealmService();
         UserRealm tenantUserRealm = realmService.getTenantUserRealm(tenantId);
         return (AbstractUserStoreManager) tenantUserRealm.getUserStoreManager();
+    }
+
+    /**
+     * Check whether the legacy authorization runtime is enabled or not.
+     *
+     * @return True if the legacy authorization runtime is enabled.
+     */
+    public static boolean isLegacyAuthzRuntime() {
+
+        return CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,12 @@
                 <artifactId>org.wso2.carbon.user.core</artifactId>
                 <version>${carbon.kernel.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon</groupId>
+                <artifactId>org.wso2.carbon.utils</artifactId>
+                <version>${carbon.kernel.version}</version>
+                <scope>provided</scope>
+            </dependency>
 
             <dependency>
                 <groupId>org.wso2.carbon.identity.organization.management.core</groupId>


### PR DESCRIPTION
## Purpose
- Creating organization self service application related system user only when legacy Authorization runtime is enabled.

## Related Issue
- https://github.com/wso2/product-is/issues/17693

