### PR TITLE
Remove the obsolete logic of resolving the authenticated username of organization SSO users

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
@@ -41,7 +41,6 @@ import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.Permission;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
-import org.wso2.carbon.user.core.common.User;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.user.mgt.UserMgtConstants;
@@ -224,20 +223,6 @@ public class Utils {
      */
     public static String getAuthenticatedUsername() {
 
-        String userResidentOrganizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                .getUserResidentOrganizationId();
-        /* When user accessing a different organization, the user resident organization is populated in the carbon
-            context. That value can be used to find the username from the user ID. */
-        if (StringUtils.isNotEmpty(userResidentOrganizationId)) {
-            try {
-                 User user = getUserStoreManager(userResidentOrganizationId).getUser(getUserId(), null);
-                 if (user != null) {
-                     return user.getUsername();
-                 }
-            } catch (OrganizationManagementException | UserStoreException e) {
-                LOG.debug("Authenticated user's username could not be resolved.", e);
-            }
-        }
         return PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
     }
 
@@ -607,18 +592,6 @@ public class Utils {
 
         UUID uuid = UUID.randomUUID();
         return uuid.toString().substring(0, 12);
-    }
-
-    private static AbstractUserStoreManager getUserStoreManager(String organizationId)
-            throws UserStoreException, OrganizationManagementException {
-
-        String tenantDomain = OrganizationManagementDataHolder.getInstance().getOrganizationManager()
-                .resolveTenantDomain(organizationId);
-        int tenantId = OrganizationManagementDataHolder.getInstance().getRealmService().getTenantManager()
-                .getTenantId(tenantDomain);
-        RealmService realmService = OrganizationManagementDataHolder.getInstance().getRealmService();
-        UserRealm tenantUserRealm = realmService.getTenantUserRealm(tenantId);
-        return (AbstractUserStoreManager) tenantUserRealm.getUserStoreManager();
     }
 
     /**


### PR DESCRIPTION
## Purpose
> With this PR https://github.com/wso2-extensions/identity-carbon-auth-rest/pull/254 the correct username is set in the carbon context at the authentication valve level. Hence these type of logics are no more required.

#### Related Issues
- https://github.com/wso2/product-is/issues/17744

### Depends on
- https://github.com/wso2-extensions/identity-carbon-auth-rest/pull/254