### PR TITLE
Oracle db tailing semicolon issue fixed

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
@@ -195,7 +195,7 @@ public class SQLConstants {
     public static final String GET_CHILD_ORGANIZATIONS = "SELECT UM_ORG.UM_ID, UM_ORG.UM_ORG_NAME, " +
             "UM_ORG.UM_CREATED_TIME FROM UM_ORG JOIN UM_ORG_HIERARCHY ON UM_ORG.UM_ID = UM_ORG_HIERARCHY.UM_ID " +
             "WHERE UM_ORG_HIERARCHY.UM_PARENT_ID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_PARENT_ID +
-            "; AND UM_ORG_HIERARCHY.DEPTH %s ;";
+            "; AND UM_ORG_HIERARCHY.DEPTH %s ";
 
     public static final String GET_CHILD_ORGANIZATION_IDS = "SELECT UM_ID FROM UM_ORG WHERE UM_PARENT_ID = :" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_PARENT_ID + ";";


### PR DESCRIPTION
## Purpose
> GET_CHILD_ORGANIZATIONS query fails with ORA-00933: SQL command not properly ended
This is due to tailing semicolon in the query

## Related Issues
> * https://github.com/wso2/product-is/issues/17974