### PR TITLE
Allowing exclamation mark to be used in organization name

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/filter/FilterTreeBuilder.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/filter/FilterTreeBuilder.java
@@ -71,6 +71,7 @@ public class FilterTreeBuilder {
         input.wordChars('.', '.');
         input.wordChars('*', '*');
         input.wordChars('/', '/');
+        input.wordChars('!', '!');
 
         tokenList = new ArrayList<>();
         StringBuilder concatenatedString = new StringBuilder();


### PR DESCRIPTION
### Related issues
- https://github.com/wso2/product-is/issues/18963

### Purpose
Fixing the bug where the organization names created with exclamation mark `!` cannot be edited in the console UI. By adding it to the list of enabled characters.
