### PR TITLE
Add condition to avoid logic execution for super tenant after getting the ancestorOrganizationIds

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationGroupResidentResolverServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationGroupResidentResolverServiceImpl.java
@@ -55,7 +55,7 @@ public class OrganizationGroupResidentResolverServiceImpl implements Organizatio
                     organizationManagementDAO.getAncestorOrganizationIds(accessedOrganizationId);
             int subOrgStartLevel = Utils.getSubOrgStartLevel();
             if (ancestorOrganizationIds != null) {
-                if (subOrgStartLevel > 1 ) {
+                if (subOrgStartLevel > 1) {
                     ancestorOrganizationIds.remove(ancestorOrganizationIds.size() - 1);
                 }
                 for (String organizationId : ancestorOrganizationIds) {

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationGroupResidentResolverServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationGroupResidentResolverServiceImpl.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.organization.management.service.dao.impl.Organiz
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
 import org.wso2.carbon.identity.organization.management.service.internal.OrganizationManagementDataHolder;
+import org.wso2.carbon.identity.organization.management.service.util.Utils;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
@@ -52,7 +53,11 @@ public class OrganizationGroupResidentResolverServiceImpl implements Organizatio
         try {
             List<String> ancestorOrganizationIds =
                     organizationManagementDAO.getAncestorOrganizationIds(accessedOrganizationId);
+            int subOrgStartLevel = Utils.getSubOrgStartLevel();
             if (ancestorOrganizationIds != null) {
+                if (subOrgStartLevel > 1 ) {
+                    ancestorOrganizationIds.remove(ancestorOrganizationIds.size() - 1);
+                }
                 for (String organizationId : ancestorOrganizationIds) {
                     String associatedTenantDomainForOrg = resolveTenantDomainForOrg(organizationId);
                     if (StringUtils.isBlank(associatedTenantDomainForOrg)) {


### PR DESCRIPTION
## Purpose
This will avoid the execution of the rest of the logic if the tenant domain is resolved as the super tenant. Super tenant is the last item of the ancestorOrganizationIds and from this changes, we are removing the super tenant when the sub org start level is above 1. 
