### PR TITLE
Remove domain from username when checking authorized organizations

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.organization.management.service.model.Organizati
 import org.wso2.carbon.identity.organization.management.service.model.OrganizationAttribute;
 import org.wso2.carbon.identity.organization.management.service.model.PatchOperation;
 import org.wso2.carbon.identity.organization.management.service.util.Utils;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -805,7 +806,12 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
 
         List<BasicOrganization> organizations;
         NamedJdbcTemplate namedJdbcTemplate = Utils.getNewTemplate();
+        String username = getAuthenticatedUsername();
+        if (StringUtils.isNotEmpty(username)) {
+            username = UserCoreUtil.removeDomainFromName(username);
+        }
         try {
+            String finalUsername = username;
             organizations = namedJdbcTemplate.executeQuery(sqlStmt,
                     (resultSet, rowNumber) -> {
                         BasicOrganization organization = new BasicOrganization();
@@ -817,7 +823,7 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
                     },
                     namedPreparedStatement -> {
                         namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_USER_ID, getUserId());
-                        namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_USER_NAME, getAuthenticatedUsername());
+                        namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_USER_NAME, finalUsername);
                         namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_USER_DOMAIN,
                                 getOrganizationUserInvitationPrimaryUserDomain());
                         if (parentIdFilterAttributeValueMap.isEmpty()) {


### PR DESCRIPTION
## Purpose
> $subject

There can be situations where username is appended with the user store domain.
(Here we are assuming the request initiated user name and corresponding shared user name is same)

<img width="622" alt="Screenshot 2024-04-17 at 22 32 51" src="https://github.com/wso2/identity-organization-management-core/assets/35717390/c49fc9e2-1994-4514-84f9-2f6f608013a3">
