### PR TITLE
Implement `NotImplementedException` for Organization Management

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2022-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -719,7 +719,11 @@ public class OrganizationManagementConstants {
                 "organization with ID: %s."),
         ERROR_CODE_ERROR_REVOKING_SHARED_APP_TOKENS("65138", "Error while revoking tokens issued for " +
                 "shared application.", "Server encountered an error while revoking tokens issued for application: " +
-                "%s in organization with ID: %s");
+                "%s in organization with ID: %s"),
+        ERROR_CODE_ERROR_GETTING_PARENT_APP_ID("65139",
+                "Error while retrieving shared parent app id of shared application.",
+                "Server encountered an error while retrieving shared parent app ID of main application: " +
+                        "%s for child organization with ID: %s");;
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -721,7 +721,7 @@ public class OrganizationManagementConstants {
                 "shared application.", "Server encountered an error while revoking tokens issued for application: " +
                 "%s in organization with ID: %s"),
         ERROR_CODE_ERROR_GETTING_PARENT_APP_ID("65139",
-                "Error while retrieving shared parent app id of shared application.",
+                "Error while retrieving shared parent application ID.",
                 "Server encountered an error while retrieving shared parent app ID of main application: " +
                         "%s for child organization with ID: %s");;
 

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/exception/NotImplementedException.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/exception/NotImplementedException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.service.exception;
+
+/**
+ * The exception to throw when the code is not implemented.
+ */
+public class NotImplementedException extends RuntimeException {
+
+    private static final long serialVersionUID = 5191938786934510986L;
+
+    public NotImplementedException() {
+        super();
+    }
+
+    public NotImplementedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotImplementedException(String message) {
+        super(message);
+    }
+
+    public NotImplementedException(Throwable cause) {
+        super(cause);
+    }
+
+}


### PR DESCRIPTION
## Purpose
- Implement `NotImplementedException`.
- Add error constant to be used when server error occurs while retrieving parent app id.
