### PR TITLE
Add Error Enum for Parent App ID Retrieval

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2022-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -719,7 +719,11 @@ public class OrganizationManagementConstants {
                 "organization with ID: %s."),
         ERROR_CODE_ERROR_REVOKING_SHARED_APP_TOKENS("65138", "Error while revoking tokens issued for " +
                 "shared application.", "Server encountered an error while revoking tokens issued for application: " +
-                "%s in organization with ID: %s");
+                "%s in organization with ID: %s"),
+        ERROR_CODE_ERROR_GETTING_PARENT_APP_ID("65139",
+                "Error while retrieving shared parent app ID.",
+                "Server encountered an error while retrieving shared parent app ID of main application: " +
+                        "%s for child organization with ID: %s");
 
         private final String code;
         private final String message;


### PR DESCRIPTION
## Purpose
- Add the following error enum which represent server error while retrieving the parent app ID of a given shared app.
    - `ERROR_CODE_ERROR_GETTING_PARENT_APP_ID ` 
