### PR TITLE
Fixed wrong pagination results returned from the GET organizations DAO

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
@@ -1605,7 +1605,7 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
         }
         for (Map.Entry<String, String> entry : filterAttributeValue.entrySet()) {
             if (timestampTypeAttributes.contains(entry.getKey())) {
-                namedPreparedStatement.setTimeStamp(entry.getKey(), Timestamp.valueOf(entry.getValue()), CALENDAR);
+                namedPreparedStatement.setTimeStamp(entry.getKey(), Timestamp.valueOf(entry.getValue()), null);
             } else {
                 namedPreparedStatement.setString(entry.getKey(), entry.getValue());
             }


### PR DESCRIPTION
## Purpose
Related to: https://github.com/wso2/product-is/issues/20700
> When getting organizations from the /organization GET API with an after or before pagination cursor, the returned lists of organizations are wrong if the local time zone of the system running the code to a different time zone than UTC.

## Approach
```
namedPreparedStatement.setTimeStamp(entry.getKey(), Timestamp.valueOf(entry.getValue()), CALENDAR);
```

- Here a UTC Calendar instance is passed when setting the Timestamp value. 
- This approach takes the time string value provided (from entry.getValue()), which is already specified for the UTC zone, and converts it to UTC according to the local time zone.
- Therefore the Timestamp value changes according to the local system time zone, leading to incorrect pagination.

## Related Issue
- This PR will revert the change done in the https://github.com/wso2/identity-organization-management-core/pull/135 PR.
- The above change was introduced as a workaround for the issue that arises when attempting to compare datetime values in an MSSQL server, where you may encounter unexpected behavior where comparisons do not work as anticipated, even if the values appear to be identical. 
- This issue was resolved by the https://github.com/wso2/identity-organization-management-core/pull/137 change instead. 
- Therefore, the change by https://github.com/wso2/identity-organization-management-core/pull/135 PR can be reverted.