### PR TITLE
Improve exception handling when error occured during the rollback of organization creation failure

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -185,8 +185,8 @@ public class OrganizationManagerImpl implements OrganizationManager {
             try {
                 deleteOrganization(organization.getId());
             } catch (OrganizationManagementException exception) {
-                LOG.error("Server encountered error while delete organization as rollback of organization " +
-                        "creation failure", exception);
+                LOG.error("The server encountered an error while deleting the organization due to a rollback " +
+                        "after a failed organization creation.", exception);
             }
             throw e;
         }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -20,6 +20,8 @@ package org.wso2.carbon.identity.organization.management.service;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
 import org.wso2.carbon.identity.organization.management.service.dao.OrganizationManagementDAO;
@@ -155,6 +157,8 @@ import static org.wso2.carbon.identity.organization.management.service.util.Util
  */
 public class OrganizationManagerImpl implements OrganizationManager {
 
+    private static final Log LOG = LogFactory.getLog(OrganizationManagerImpl.class);
+
     private final OrganizationManagementDAO organizationManagementDAO =
             new CacheBackedOrganizationManagementDAO(new OrganizationManagementDAOImpl());
 
@@ -178,7 +182,12 @@ public class OrganizationManagerImpl implements OrganizationManager {
             getListener().postAddOrganization(organization);
         } catch (OrganizationManagementException e) {
             // Rollback created organization.
-            deleteOrganization(organization.getId());
+            try {
+                deleteOrganization(organization.getId());
+            } catch (OrganizationManagementException exception) {
+                LOG.error("Server encountered error while delete organization as rollback of organization " +
+                        "creation failure", exception);
+            }
             throw e;
         }
         return organization;

--- a/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
@@ -671,6 +671,21 @@ public class OrganizationManagerImplTest {
         Assert.assertEquals(organizationManager.getParentOrganizationId(ORG2_ID), ORG1_ID);
     }
 
+    @Test(expectedExceptions = OrganizationManagementException.class,
+            expectedExceptionsMessageRegExp = ".*Server encountered error while executing post listeners.*")
+    public void testAddOrganizationFailWhileRoleBack() throws Exception {
+
+        Organization sampleOrganization = getOrganization(UUID.randomUUID().toString(), NEW_ORG_NAME, ORG_DESCRIPTION,
+                SUPER_ORG_ID, STRUCTURAL.toString());
+        TestUtils.mockCarbonContext(SUPER_ORG_ID);
+        OrganizationManagerListener mockOrgMgtListener = OrganizationManagementDataHolder.getInstance().getOrganizationManagerListener();
+        Mockito.doThrow(new OrganizationManagementException("Server encountered error while executing post listeners."))
+                .when(mockOrgMgtListener).postAddOrganization(sampleOrganization);
+        Mockito.doThrow(new OrganizationManagementException("Server encountered error while deleting organization."))
+                .when(mockOrgMgtListener).preDeleteOrganization(sampleOrganization.getId());
+        organizationManager.addOrganization(sampleOrganization);
+    }
+
     private void setOrganizationAttributes(Organization organization, String key, String value) {
 
         OrganizationAttribute organizationAttribute = new OrganizationAttribute(key, value);

--- a/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
@@ -678,7 +678,8 @@ public class OrganizationManagerImplTest {
         Organization sampleOrganization = getOrganization(UUID.randomUUID().toString(), NEW_ORG_NAME, ORG_DESCRIPTION,
                 SUPER_ORG_ID, STRUCTURAL.toString());
         TestUtils.mockCarbonContext(SUPER_ORG_ID);
-        OrganizationManagerListener mockOrgMgtListener = OrganizationManagementDataHolder.getInstance().getOrganizationManagerListener();
+        OrganizationManagerListener mockOrgMgtListener = OrganizationManagementDataHolder.getInstance()
+                .getOrganizationManagerListener();
         Mockito.doThrow(new OrganizationManagementException("Server encountered error while executing post listeners."))
                 .when(mockOrgMgtListener).postAddOrganization(sampleOrganization);
         Mockito.doThrow(new OrganizationManagementException("Server encountered error while deleting organization."))


### PR DESCRIPTION
## Purpose
> There is a rollback mechanism when org creation failure. But if the org deletion cause an exception the original issue which cause for the failure of the org creation flow will be not logged. Ideally, the published logs contains not the reason for org creation failure, but the reason for the failure of the rollback.
