### PR TITLE
Handle depth -1 in isOrganization check

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/OrganizationManagementUtil.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/OrganizationManagementUtil.java
@@ -84,6 +84,10 @@ public class OrganizationManagementUtil {
         OrganizationManager organizationManager = OrganizationManagementDataHolder.getInstance()
                 .getOrganizationManager();
         int organizationDepth = organizationManager.getOrganizationDepthInHierarchy(organizationUUID);
+
+        if (organizationDepth == -1) {
+            return false;
+        }
         return organizationDepth >= Utils.getSubOrgStartLevel();
     }
 }


### PR DESCRIPTION
## Purpose
When a suborg is deleted since stale data remains in SP_SHARED_APP table, when a shared parent app is updated those updates are tried to be done in non-existing deleted suborgs as well. For those nonexistent suborgs the hierarchy depth is returned as -1, and we can use this to return false in the isOrganization() check, which will in turn stop the other tasks related to shared app update from happening.

## Related issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/26168

