### PR TITLE
Revert ROOT_TENANT_DOMAIN constant removal

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -81,6 +81,7 @@ public class OrganizationManagementConstants {
     public static final List<String> ALL_ORGANIZATION_PERMISSIONS = Collections.unmodifiableList(Arrays
             .asList(CREATE_ORGANIZATION_PERMISSION, VIEW_ORGANIZATION_PERMISSION, UPDATE_ORGANIZATION_PERMISSION,
                     DELETE_ORGANIZATION_PERMISSION));
+    public static final String ROOT_TENANT_DOMAIN = "RootTenantDomain";
     public static final String DESC_SORT_ORDER = "DESC";
     public static final String ASC_SORT_ORDER = "ASC";
 


### PR DESCRIPTION
## Purpose
$Subject

This PR reverts the accidental removal of the ROOT_TENANT_DOMAIN from the PR: https://github.com/wso2/identity-organization-management-core/pull/144