### PR TITLE
Block organization name with HTML content

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -93,6 +93,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_NO_PARENT_ORG;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORGANIZATION_HAS_CHILD_ORGANIZATIONS;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORGANIZATION_ID_UNDEFINED;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORGANIZATION_NAME_CONTAINS_HTML_CONTENT;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORGANIZATION_NAME_EXIST_IN_CHILD_ORGANIZATIONS;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORGANIZATION_NAME_RESERVED;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT;
@@ -150,6 +151,7 @@ import static org.wso2.carbon.identity.organization.management.service.util.Util
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.getUserId;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.handleClientException;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.handleServerException;
+import static org.wso2.carbon.identity.organization.management.service.util.Utils.hasHtmlContent;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.isSubOrganization;
 
 /**
@@ -754,6 +756,10 @@ public class OrganizationManagerImpl implements OrganizationManager {
         if (StringUtils.equalsIgnoreCase(SUPER, organizationName)) {
             throw handleClientException(ERROR_CODE_ORGANIZATION_NAME_RESERVED, SUPER);
         }
+        if (hasHtmlContent(organizationName)) {
+            throw handleClientException(ERROR_CODE_ORGANIZATION_NAME_CONTAINS_HTML_CONTENT);
+        }
+
     }
 
     private void validateParentOrganization(Organization organization) throws OrganizationManagementException {

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -759,7 +759,6 @@ public class OrganizationManagerImpl implements OrganizationManager {
         if (hasHtmlContent(organizationName)) {
             throw handleClientException(ERROR_CODE_ORGANIZATION_NAME_CONTAINS_HTML_CONTENT);
         }
-
     }
 
     private void validateParentOrganization(Organization organization) throws OrganizationManagementException {

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -380,9 +380,8 @@ public class OrganizationManagementConstants {
                 "The shared user profile attributes are read only."),
         ERROR_CODE_ORGANIZATION_OWNER_NOT_EXIST("60096", "The assigned organization owner does not exist ",
                 "The assigned organization owner is not found in the tenant with ID: %s"),
-        ERROR_CODE_ORGANIZATION_NAME_CONTAINS_HTML_CONTENT("60097", "HTML contents are not allowed for " +
-                "organization name.", "Organization name with HTML content is not allowed due to possible XSS " +
-                "attacks."),
+        ERROR_CODE_ORGANIZATION_NAME_CONTAINS_HTML_CONTENT("60097", "Invalid organization name.",
+                "HTML content is not allowed in organization name."),
 
         // Server errors.
         ERROR_CODE_UNEXPECTED("65001", "Unexpected processing error",

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -380,6 +380,9 @@ public class OrganizationManagementConstants {
                 "The shared user profile attributes are read only."),
         ERROR_CODE_ORGANIZATION_OWNER_NOT_EXIST("60096", "The assigned organization owner does not exist ",
                 "The assigned organization owner is not found in the tenant with ID: %s"),
+        ERROR_CODE_ORGANIZATION_NAME_CONTAINS_HTML_CONTENT("60097", "HTML contents are not allowed for " +
+                "organization name.", "Organization name with HTML content is not allowed due to possible XSS " +
+                "attacks."),
 
         // Server errors.
         ERROR_CODE_UNEXPECTED("65001", "Unexpected processing error",

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2022-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -29,8 +29,6 @@ import org.wso2.carbon.database.utils.jdbc.NamedJdbcTemplate;
 import org.wso2.carbon.database.utils.jdbc.exceptions.DataAccessException;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManagerImpl;
-import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
-import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverServiceImpl;
 import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementClientException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
@@ -51,6 +49,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 import javax.sql.DataSource;
 
@@ -74,9 +73,8 @@ public class Utils {
 
     private static final Log LOG = LogFactory.getLog(Utils.class);
     private static DataSource dataSource;
-    private static final OrganizationUserResidentResolverService organizationUserResidentResolverService =
-            new OrganizationUserResidentResolverServiceImpl();
     private static final OrganizationManager organizationManager = new OrganizationManagerImpl();
+    private static final Pattern htmlContentPattern = Pattern.compile(".*<[^>]+(/>|>.*?</[^>]+>).*");
 
     /**
      * Throw an OrganizationManagementClientException upon client side error in organization management.
@@ -629,4 +627,10 @@ public class Utils {
 
         return CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME;
     }
+
+    public static boolean hasHtmlContent(String orgName) {
+
+        return htmlContentPattern.matcher(orgName).find();
+    }
+
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
@@ -77,6 +77,7 @@ public class OrganizationManagerImplTest {
     private static final String ORG2_NAME = "XYZ Builders";
     private static final String ORG3_NAME = "Greater";
     private static final String NON_EXISTING_ORG_NAME = "Dummy Builders";
+    private static final String ORG_NAME_WITH_HTML_CONTENT = "<a href=\"evil.com\">Click me</a>";
     private static final String NEW_ORG1_NAME = "ABC Builders New";
     private static final String ORG_DESCRIPTION = "This is a construction company.";
     private static final String NEW_ORG_NAME = "New Org";
@@ -272,6 +273,14 @@ public class OrganizationManagerImplTest {
 
         Organization organization = getOrganization(UUID.randomUUID().toString(), SUPER, ORG_DESCRIPTION, ORG1_NAME,
                 TENANT.toString());
+        organizationManager.addOrganization(organization);
+    }
+
+    @Test(expectedExceptions = OrganizationManagementClientException.class)
+    public void testAddOrganizationWithNameIncludeHTMLContent() throws Exception {
+
+        Organization organization = getOrganization(UUID.randomUUID().toString(), ORG_NAME_WITH_HTML_CONTENT,
+                ORG_DESCRIPTION, ORG1_NAME, TENANT.toString());
         organizationManager.addOrganization(organization);
     }
 


### PR DESCRIPTION
## Purpose

The organization name can have any character as there is no specific regular expression defined to validate organization name. Due to that malicious organization names with HTML content can be created and those organization names will be shown in the email send for the user invitations etc..

Email templates can be updated with HTML content by the administrators also. But as we have the capability to validate the organization name with HTML content while creating and update organizations, its better to have a validation until proper organization name regular expression is defined.