### PR TITLE
Check for invalid organization IDs like empty string or null values passed to resolve tenant domain function

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -475,6 +475,9 @@ public class OrganizationManagerImpl implements OrganizationManager {
     @Override
     public String resolveTenantDomain(String organizationId) throws OrganizationManagementException {
 
+        if (StringUtils.isEmpty(organizationId)) {
+            throw handleClientException(ERROR_CODE_INVALID_ORGANIZATION, organizationId);
+        }
         if (StringUtils.equals(SUPER_ORG_ID, organizationId)) {
             // super tenant domain will be returned.
             return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;

--- a/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
@@ -696,6 +696,12 @@ public class OrganizationManagerImplTest {
         organizationManager.addOrganization(sampleOrganization);
     }
 
+    @Test(expectedExceptions = OrganizationManagementClientException.class)
+    public void testResolveTenantDomainWithEmptyOrganizationId() throws OrganizationManagementException {
+
+        organizationManager.resolveTenantDomain("");
+    }
+
     private void setOrganizationAttributes(Organization organization, String key, String value) {
 
         OrganizationAttribute organizationAttribute = new OrganizationAttribute(key, value);


### PR DESCRIPTION
## Purpose

When the organization ID passed to resolve the tenant domain is null, it checks in cache. The cache key is based on organization ID which is derived by calling the hash code method. There is possibility of NPE at this place [1]

[1] - https://github.com/wso2/identity-organization-management-core/blob/main/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/cache/OrganizationIdCacheKey.java#L62


We may able to improve the hash code generation logic to not to cause a NPE also.
Any how the service layer should have validation for such cases like not Empty checks.