### PR TITLE
Add new error code for updating organization user associations

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -26,7 +26,7 @@ jobs:
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-m2
         with:

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -746,9 +746,9 @@ public class OrganizationManagementConstants {
         ERROR_WHILE_RETRIEVING_ORG_DISCOVERY_ATTRIBUTES("65142",
                 "Error while retrieving organization discovery attributes",
                 "Error while retrieving organization discovery attributes for tenantDomain: %s"),
-        ERROR_CODE_ERROR_UPDATE_ORGANIZATION_USER_ASSOCIATIONS("65143", "Unable to update organization " +
-                "user associations.", "Server encountered an error while updating organization user " +
-                "associations for the user.");
+        ERROR_CODE_ERROR_UPDATE_ORGANIZATION_USER_ASSOCIATIONS("65143",
+                "Unable to update organization user associations.",
+                "Server encountered an error while updating organization user associations for the user.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -745,7 +745,10 @@ public class OrganizationManagementConstants {
                 "links for organization: %s."),
         ERROR_WHILE_RETRIEVING_ORG_DISCOVERY_ATTRIBUTES("65142",
                 "Error while retrieving organization discovery attributes",
-                "Error while retrieving organization discovery attributes for tenantDomain: %s");
+                "Error while retrieving organization discovery attributes for tenantDomain: %s"),
+        ERROR_CODE_ERROR_UPDATE_ORGANIZATION_USER_ASSOCIATIONS("65143", "Unable to update organization " +
+                "user associations.", "Server encountered an error while updating organization user " +
+                "associations for the user.");
 
         private final String code;
         private final String message;


### PR DESCRIPTION
## Purpose
The purpose of this change is to introduce a new error code, `ERROR_CODE_UPDATE_ORGANIZATION_USER_ASSOCIATIONS`, which will be used to indicate failures when updating organization user associations.

## Goals
- Introduce a specific error code to improve error handling and debugging for organization user association updates.
- Ensure consistency in error messages by following a structured format.

## Approach
Added 
```
ERROR_CODE_UPDATE_ORGANIZATION_USER_ASSOCIATIONS("65143", "Unable to update organization user associations.", "Server encountered an error while updating organization user associations for the user.")
```
to `ErrorMessages` enum.

---

## Related Issue
[Introduce Error Code for Organization User Association Update Failure #22983](https://github.com/wso2/product-is/issues/22983)