### PR TITLE
Add new error code for checking organization user associations

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -748,7 +748,10 @@ public class OrganizationManagementConstants {
                 "Error while retrieving organization discovery attributes for tenantDomain: %s"),
         ERROR_CODE_ERROR_UPDATE_ORGANIZATION_USER_ASSOCIATIONS("65143",
                 "Unable to update organization user associations.",
-                "Server encountered an error while updating organization user associations for the user.");
+                "Server encountered an error while updating organization user associations for the user."),
+        ERROR_CODE_ERROR_CHECK_ORGANIZATION_USER_ASSOCIATIONS("65144",
+                "Unable to check if organization user associations exists.",
+                "Server encountered an error while checking organization user associations for the user."),;
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -750,8 +750,8 @@ public class OrganizationManagementConstants {
                 "Unable to update organization user associations.",
                 "Server encountered an error while updating organization user associations for the user."),
         ERROR_CODE_ERROR_CHECK_ORGANIZATION_USER_ASSOCIATIONS("65144",
-                "Unable to check if organization user associations exists.",
-                "Server encountered an error while checking organization user associations for the user."),;
+                "Unable to check if organization user associations exist.",
+                "Server encountered an error while checking organization user associations for the user.");
 
         private final String code;
         private final String message;


### PR DESCRIPTION
## Purpose
The purpose of this change is to introduce a new error code, `ERROR_CODE_CHECK_ORGANIZATION_USER_ASSOCIATIONS`, which will be used to indicate failures when checking for organization user associations.

## Goals
- Introduce a specific error code to improve error handling and debugging for organization user association checkings.
- Ensure consistency in error messages by following a structured format.

## Approach
Added 
```
ERROR_CODE_ERROR_CHECK_ORGANIZATION_USER_ASSOCIATIONS("65144", "Unable to check if organization user associations exist.", "Server encountered an error while checking organization user associations for the user.")
```
to `ErrorMessages` enum.

---

## Related Issue
[Introduce Error Code for Organization User Association Checking Failure #22990](https://github.com/wso2/product-is/issues/22990)