### PR TITLE
Add support for DB2 and PostgreSQL detection in Identity Organization Management Core

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
@@ -25,10 +25,10 @@ public class SQLConstants {
 
     // Database types
     public static final String ORACLE = "oracle";
-
     public static final String MICROSOFT = "microsoft";
-
     public static final String MYSQL = "mysql";
+    public static final String DB2 = "db2";
+    public static final String POSTGRESQL = "postgresql";
 
     public static final String PERMISSION_LIST_PLACEHOLDER = "_PERMISSION_LIST_";
     public static final String USER_NAME_LIST_PLACEHOLDER = "_SHARED_USER_NAMES_";

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
@@ -63,9 +63,11 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.IS_ORG_QUALIFIED_URLS_SUPPORTED_FOR_LEVEL_ONE_ORGS;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATH_SEPARATOR;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.SUB_ORG_START_LEVEL;
+import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.DB2;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.MICROSOFT;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.MYSQL;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.ORACLE;
+import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.POSTGRESQL;
 import static org.wso2.carbon.user.core.UserCoreConstants.INTERNAL_DOMAIN;
 
 /**
@@ -157,6 +159,28 @@ public class Utils {
     public static boolean isMySqlDB() throws OrganizationManagementServerException {
 
         return isDBTypeOf(MYSQL);
+    }
+
+    /**
+     * Check whether the string, "db2", contains in the driver name or db product name.
+     *
+     * @return true if the database type matches the driver type, false otherwise.
+     * @throws OrganizationManagementServerException If error occurred while checking the DB metadata.
+     */
+    public static boolean isDB2DB() throws OrganizationManagementServerException {
+
+        return isDBTypeOf(DB2);
+    }
+
+    /**
+     * Check whether the string, "postgresql", contains in the driver name or db product name.
+     *
+     * @return true if the database type matches the driver type, false otherwise.
+     * @throws OrganizationManagementServerException If error occurred while checking the DB metadata.
+     */
+    public static boolean isPostgreSqlDB() throws OrganizationManagementServerException {
+
+        return isDBTypeOf(POSTGRESQL);
     }
 
     /**


### PR DESCRIPTION
## Purpose
Extend the database detection mechanism in Identity Organization Management Core by adding support for DB2 and PostgreSQL.

## Goals
- Introduce constants for `DB2` and `POSTGRESQL` database types.
- Implement methods `isDB2DB()` and `isPostgreSqlDB()` to detect these databases.
- Ensure consistency with existing database detection logic.

## Approach
- Defined `DB2` and `POSTGRESQL` as constants.
- Implemented `isDB2DB()` and `isPostgreSqlDB()` using the existing isDBTypeOf(String dbType) method.
- Maintained consistency with existing methods such as `isOracleDB()`, `isMSSqlDB()`, and `isMySqlDB()`.
- Ensured proper handling of database metadata checks to prevent errors during detection.