### PR TITLE
Add util method to fetch the super root organization name

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/OrganizationManagementUtil.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/OrganizationManagementUtil.java
@@ -27,6 +27,8 @@ import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.SUPER_ORG_ID;
+
 /**
  * This class provides utility functions for the Organization Management.
  */
@@ -102,5 +104,23 @@ public class OrganizationManagementUtil {
         String orgId = organizationManager.resolveOrganizationId(tenantDomain);
         String rootOrganizationId = organizationManager.getPrimaryOrganizationId(orgId);
         return organizationManager.resolveTenantDomain(rootOrganizationId);
+    }
+
+    /**
+     * Get the name of the Super Root Organization.
+     *
+     * <p>
+     * This method provides the proper way to retrieve the Super Organization name.
+     * Please avoid using the hardcoded "SUPER" constant in implementations.
+     * </p>
+     *
+     * @return The name of the Super Root Organization.
+     * @throws OrganizationManagementException If an error occurs while retrieving the Super Root Organization name.
+     */
+    public static String getSuperRootOrgName() throws OrganizationManagementException {
+
+        OrganizationManager organizationManager = OrganizationManagementDataHolder.getInstance()
+                .getOrganizationManager();
+        return organizationManager.getOrganizationNameById(SUPER_ORG_ID);
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/util/OrganizationManagementUtilTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/util/OrganizationManagementUtilTest.java
@@ -29,6 +29,8 @@ import org.wso2.carbon.identity.organization.management.service.internal.Organiz
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.SUPER;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.SUPER_ORG_ID;
 
 /**
  * Unit tests for Organization Management Util class.
@@ -62,5 +64,14 @@ public class OrganizationManagementUtilTest {
         verify(organizationManager).resolveOrganizationId(tenantDomain);
         verify(organizationManager).getPrimaryOrganizationId(organizationId);
         verify(organizationManager).resolveTenantDomain(rootOrganizationId);
+    }
+
+    @Test
+    public void testGetSuperRootOrgName() throws OrganizationManagementException {
+
+        when(organizationManager.getOrganizationNameById(SUPER_ORG_ID)).thenReturn(SUPER);
+
+        assertEquals(OrganizationManagementUtil.getSuperRootOrgName(), SUPER);
+        verify(organizationManager).getOrganizationNameById(SUPER_ORG_ID);
     }
 }


### PR DESCRIPTION
## Purpose
$subject

This method provides the proper way to retrieve the Super Organization name. Please avoid using the hardcoded "SUPER" constant in implementations.