### PR TITLE
Populate haschildren value in BasicOrganization object from getBasicOrganizationDetailsByOrgIDs() DAO method

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
@@ -562,7 +562,9 @@ public class SQLConstants {
             "OFFSET 0 ROWS FETCH NEXT :" + SQLPlaceholders.DB_SCHEMA_LIMIT + "; ROWS ONLY;";
 
     public static final String GET_BASIC_ORG_DETAILS_BY_ORG_IDS = "SELECT U.UM_ID, U.UM_ORG_NAME, U.UM_STATUS, " +
-            "U.UM_CREATED_TIME, T.UM_DOMAIN_NAME FROM UM_ORG U JOIN UM_TENANT T ON U.UM_ID = T.UM_ORG_UUID " +
+            "U.UM_CREATED_TIME, T.UM_DOMAIN_NAME, CASE WHEN EXISTS " +
+            "( SELECT 1 FROM UM_ORG C WHERE C.UM_PARENT_ID = U.UM_ID ) THEN 1 ELSE 0 END AS HAS_CHILDREN " +
+            "FROM UM_ORG U JOIN UM_TENANT T ON U.UM_ID = T.UM_ORG_UUID " +
             "WHERE U.UM_ID IN (%s)";
 
     public static final String GET_ANCESTOR_ORG_DETAILS = "SELECT H.UM_PARENT_ID, O.UM_ORG_NAME, (( " +

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
@@ -1507,6 +1507,7 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
                     basicOrganization.setStatus(resultSet.getString(VIEW_STATUS_COLUMN));
                     basicOrganization.setCreated(resultSet.getString(VIEW_CREATED_TIME_COLUMN));
                     basicOrganization.setOrganizationHandle(resultSet.getString(VIEW_TENANT_DOMAIN_COLUMN));
+                    basicOrganization.setHasChildren(resultSet.getInt(VIEW_HAS_CHILDREN_COLUMN) == 1);
                     basicOrganizationDetailsMap.put(orgId, basicOrganization);
                 } else {
                     invalidOrgIds.add(orgId);

--- a/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
@@ -963,15 +963,18 @@ public class OrganizationManagerImplTest {
         List<String> expectedIds = Arrays.asList(ORG1_ID, ORG2_ID, ORG3_ID);
         List<String> expectedNames = Arrays.asList(ORG1_NAME, ORG2_NAME, ORG3_NAME);
         List<String> expectedOrganizationHandles = Arrays.asList(ORG1_HANDLE, ORG2_HANDLE, ORG3_HANDLE);
+        List<Boolean> expectedHasChildren = Arrays.asList(true, false, false);
 
         return new Object[][] {
-                { orgIds, expectedIds, expectedNames, expectedOrganizationHandles }
+                { orgIds, expectedIds, expectedNames, expectedOrganizationHandles, expectedHasChildren }
         };
     }
 
     @Test(dataProvider = "dataForGetBasicOrganizationDetailsByOrgIDs")
     public void testGetBasicOrganizationDetailsByOrgIDs(List<String> orgIds, List<String> expectedIds,
-                                               List<String> expectedNames, List<String> expectedOrganizationHandles)
+                                                        List<String> expectedNames,
+                                                        List<String> expectedOrganizationHandles,
+                                                        List<Boolean> expectedHasChildren)
             throws OrganizationManagementException {
 
         TestUtils.mockCarbonContext(SUPER_ORG_ID);
@@ -986,6 +989,7 @@ public class OrganizationManagerImplTest {
             Assert.assertEquals(org.getId(), expectedIds.get(index));
             Assert.assertEquals(org.getName(), expectedNames.get(index));
             Assert.assertEquals(org.getOrganizationHandle(), expectedOrganizationHandles.get(index));
+            Assert.assertEquals(org.hasChildren(), expectedHasChildren.get(index).booleanValue());
         }
     }
 
@@ -1123,12 +1127,18 @@ public class OrganizationManagerImplTest {
         // Assert ORG_1 has children.
         Organization organization1 = organizationManager.getOrganization(ORG1_ID, false, false, false);
         assertTrue(organization1.hasChildren());
+        BasicOrganization basicOrganization = organizationManager.getBasicOrganizationDetailsByOrgIDs(
+                Collections.singletonList(ORG1_ID)).get(ORG1_ID);
+        assertTrue(basicOrganization.hasChildren());
         PrivilegedCarbonContext.getThreadLocalCarbonContext().setOrganizationId(ORG1_ID);
         // Delete ORG_2.
         organizationManager.deleteOrganization(ORG2_ID);
         // Assert ORG_1 don't have children.
         organization1 = organizationManager.getOrganization(ORG1_ID, false, false, false);
         assertFalse(organization1.hasChildren());
+        basicOrganization = organizationManager.getBasicOrganizationDetailsByOrgIDs(
+                Collections.singletonList(ORG1_ID)).get(ORG1_ID);
+        assertFalse(basicOrganization.hasChildren());
     }
 
     private void setOrganizationAttributes(Organization organization, String key, String value) {


### PR DESCRIPTION
## Purpose
Previously, `hasChildren` attribute in the BasicOrganization object was not populated from the `getBasicOrganizationDetailsByOrgIDs(List<String> orgIds)` DAO method.
That is due to missing this flow in the improvement we did through https://github.com/wso2/identity-organization-management-core/pull/190

This PR will add the neccessary query improvements to populate that value.




## Related Issue
- https://github.com/wso2/product-is/issues/24843