### PR TITLE
Add getOrganizationVersion method

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManager.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManager.java
@@ -195,6 +195,18 @@ public interface OrganizationManager {
     }
 
     /**
+     * Gets the version of a given organization.
+     *
+     * @param organizationId The id of the organization for which the version needs to be fetched.
+     * @return The version of the organization.
+     * @throws OrganizationManagementException If an exception occurs when getting the organization version.
+     */
+    default String getOrganizationVersion(String organizationId) throws OrganizationManagementException {
+
+        throw new NotImplementedException("getOrganizationVersion is not implemented in " + this.getClass().getName());
+    }
+
+    /**
      * List or search organizations authorized for the user.
      *
      * @param limit     The maximum number of records to be returned.

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -427,6 +427,18 @@ public class OrganizationManagerImpl implements OrganizationManager {
                 recursive, limit, orgId, sortOrder, expressionNodes, filteringByParentIdExpressionNodes));
     }
 
+    @Override
+    public String getOrganizationVersion(String organizationId) throws OrganizationManagementException {
+
+        if (StringUtils.isEmpty(organizationId)) {
+            throw handleClientException(ERROR_CODE_INVALID_ORGANIZATION, organizationId);
+        }
+
+        Organization organization = organizationManagementDAO.getOrganization(organizationId);
+        resolveInheritedOrganizationVersion(organization);
+        return organization.getVersion();
+    }
+
     private List<Organization> resolveInheritedOrganizationVersions(List<Organization> organizationList)
             throws OrganizationManagementException {
 

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
@@ -642,8 +642,8 @@ public class Utils {
     private static boolean isOrgVersionApplicable(String tenantDomain, String minimumApplicableVersion)
             throws OrganizationManagementException {
 
-        String orgVersion = organizationManager.getOrganization(
-                organizationManager.resolveOrganizationId(tenantDomain), false, false).getVersion();
+        String orgVersion = organizationManager.getOrganizationVersion(
+                organizationManager.resolveOrganizationId(tenantDomain));
         if (StringUtils.isBlank(orgVersion) || StringUtils.isBlank(minimumApplicableVersion)) {
             return false;
         }


### PR DESCRIPTION
## Purpose

Adds a new method `getOrganizationVersion` to obtain the version of an organization as defined in https://github.com/wso2/product-is/issues/24463.

## Related Issues

- https://github.com/wso2/product-is/issues/24283