### PR TITLE
Introduce organization version cache

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/cache/OrganizationVersionCache.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/cache/OrganizationVersionCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/cache/OrganizationVersionCache.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/cache/OrganizationVersionCache.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.service.cache;
+
+/**
+ * Cache for organization version against organization ID.
+ */
+public class OrganizationVersionCache extends BaseCache<OrganizationIdCacheKey, OrganizationVersionCacheEntry> {
+
+    private static final String CACHE_NAME = "OrganizationVersionCache";
+    private static final OrganizationVersionCache INSTANCE = new OrganizationVersionCache();
+
+    private OrganizationVersionCache() {
+
+        super(CACHE_NAME);
+    }
+
+    /**
+     * Get organization version cache instance.
+     *
+     * @return Organization version cache instance.
+     */
+    public static OrganizationVersionCache getInstance() {
+
+        return INSTANCE;
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/cache/OrganizationVersionCacheEntry.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/cache/OrganizationVersionCacheEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -11,7 +11,7 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/cache/OrganizationVersionCacheEntry.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/cache/OrganizationVersionCacheEntry.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.service.cache;
+
+/**
+ * Cache entry to store organization version.
+ */
+public class OrganizationVersionCacheEntry extends CacheEntry {
+
+    private final String version;
+
+    public OrganizationVersionCacheEntry(String version) {
+
+        this.version = version;
+    }
+
+    /**
+     * Get organization version.
+     *
+     * @return Organization version.
+     */
+    public String getVersion() {
+
+        return version;
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -867,8 +867,7 @@ public class OrganizationManagementConstants {
         ERROR_CODE_ERROR_CHECKING_ORGANIZATION_BY_NAME("65155", "Failed to check organization by name.",
                 "Error while checking organizations by a given name."),
         ERROR_CODE_ERROR_RETRIEVING_ORG_VERSION("65156", "Unable to retrieve the organization version.",
-                "Server encountered an error while retrieving the version of the organization with ID: %s " +
-                        "and tenant domain %s.");
+                "Server encountered an error while retrieving the version of the organization with ID: %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -865,7 +865,10 @@ public class OrganizationManagementConstants {
                 "Unable to retrieve minimal organization details by organization ids.",
                 "An error occurred while retrieving minimal organization details for organization id: %s"),
         ERROR_CODE_ERROR_CHECKING_ORGANIZATION_BY_NAME("65155", "Failed to check organization by name.",
-                "Error while checking organizations by a given name.");
+                "Error while checking organizations by a given name."),
+        ERROR_CODE_ERROR_RETRIEVING_ORG_VERSION("65156", "Unable to retrieve the organization version.",
+                "Server encountered an error while retrieving the version of the organization with ID: %s " +
+                        "and tenant domain %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
@@ -593,6 +593,9 @@ public class SQLConstants {
             "UM_ORG_HIERARCHY H WHERE H.UM_ID = U.UM_ID ORDER BY H.DEPTH DESC) AS DEPTH FROM UM_ORG U JOIN " +
             "UM_TENANT T ON U.UM_ID = T.UM_ORG_UUID WHERE U.UM_ID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_ID + ";";
 
+    public static final String GET_ORGANIZATION_VERSION = "SELECT UM_ORG_VERSION FROM UM_ORG WHERE UM_ID = :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_ID + ";";
+
     /**
      * SQL Placeholders.
      */

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/OrganizationManagementDAO.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/OrganizationManagementDAO.java
@@ -525,4 +525,19 @@ public interface OrganizationManagementDAO {
         throw new OrganizationManagementServerException("getBasicOrganization is not implemented in "
                 + this.getClass().getName());
     }
+
+    /**
+     * Retrieve the version of an organization.
+     *
+     * @param organizationId The organization id.
+     * @param tenantDomain   The tenant domain of the organization.
+     * @return An optional containing the organization version if it exists.
+     * @throws OrganizationManagementException If an error occurs while retrieving the organization version.
+     */
+    default Optional<String> getOrganizationVersion(String organizationId, String tenantDomain)
+            throws OrganizationManagementException {
+
+        throw new NotImplementedException("getOrganizationVersion is not implemented in "
+                + this.getClass().getName());
+    }
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
@@ -98,6 +98,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_ORGANIZATION_PERMISSIONS;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_ORGANIZATION_STATUS;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_ORGANIZATION_TYPE;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_ORG_VERSION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_PARENT_ORGANIZATION_STATUS;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_RELATIVE_ORGANIZATION_DEPTH_IN_BRANCH;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_TENANT_UUID;
@@ -191,6 +192,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORGANIZATION_TYPE;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORGANIZATION_UUID_FROM_TENANT_DOMAIN;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORGANIZATION_UUID_FROM_TENANT_ID;
+import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORGANIZATION_VERSION;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORG_WITH_VERSION_AND_USER_ASSOCIATIONS_INCLUDING_ORG_HANDLE;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORG_WITH_VERSION_AND_USER_ROLE_ASSOCIATIONS_INCLUDING_ORG_HANDLE;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORG_WITH_VERSION_BY_ID;
@@ -1606,6 +1608,21 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
         } catch (DataAccessException e) {
             throw handleServerException(ERROR_CODE_ERROR_RETRIEVING_MINIMAL_ORGANIZATION_DETAILS_BY_ORGANIZATION_ID, e,
                     organizationId);
+        }
+    }
+
+    @Override
+    public Optional<String> getOrganizationVersion(String organizationId, String tenantDomain)
+            throws OrganizationManagementException {
+
+        NamedJdbcTemplate namedJdbcTemplate = Utils.getNewTemplate();
+        try {
+            return Optional.ofNullable(namedJdbcTemplate.fetchSingleRecord(GET_ORGANIZATION_VERSION,
+                    (resultSet, rowNumber) -> resultSet.getString(1),
+                    namedPreparedStatement ->
+                            namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_ID, organizationId)));
+        } catch (DataAccessException e) {
+            throw handleServerException(ERROR_CODE_ERROR_RETRIEVING_ORG_VERSION, e, organizationId, tenantDomain);
         }
     }
 

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
@@ -1622,7 +1622,7 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
                     namedPreparedStatement ->
                             namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_ID, organizationId)));
         } catch (DataAccessException e) {
-            throw handleServerException(ERROR_CODE_ERROR_RETRIEVING_ORG_VERSION, e, organizationId, tenantDomain);
+            throw handleServerException(ERROR_CODE_ERROR_RETRIEVING_ORG_VERSION, e, organizationId);
         }
     }
 

--- a/features/org.wso2.carbon.identity.organization.management.core.server.feature/resources/organization-mgt.xml
+++ b/features/org.wso2.carbon.identity.organization.management.core.server.feature/resources/organization-mgt.xml
@@ -50,6 +50,11 @@
                    timeout="900"
                    capacity="5000"
                    isDistributed="false"/>
+            <Cache id="organization_version_cache" name="OrganizationVersionCache"
+                   enable="true"
+                   timeout="900"
+                   capacity="5000"
+                   isDistributed="false"/>
         </CacheManager>
     </CacheConfig>
 

--- a/features/org.wso2.carbon.identity.organization.management.core.server.feature/resources/organization-mgt.xml.j2
+++ b/features/org.wso2.carbon.identity.organization.management.core.server.feature/resources/organization-mgt.xml.j2
@@ -50,6 +50,11 @@
                    timeout="{{cache.tenant_domain_cache_by_orgid.timeout | default(900)}}"
                    capacity="{{cache.tenant_domain_cache_by_orgid.capacity | default(5000)}}"
                    isDistributed="false"/>
+            <Cache id="organization_version_cache" name="OrganizationVersionCache"
+                   enable="{{cache.organization_version_cache.enable | default(true)}}"
+                   timeout="{{cache.organization_version_cache.timeout | default(900)}}"
+                   capacity="{{cache.organization_version_cache.capacity | default(5000)}}"
+                   isDistributed="false"/>
 	    </CacheManager>
     </CacheConfig>
 


### PR DESCRIPTION
This pull request introduces organization version caching to improve performance and consistency when retrieving organization version information. The main changes include adding cache classes for organization version, updating DAO implementations to use the cache, and modifying configuration files to enable and configure the new cache.

**Caching enhancements:**

* Added new classes `OrganizationVersionCache` and `OrganizationVersionCacheEntry` to store and manage organization version data in cache. 
* Updated `CacheBackedOrganizationManagementDAO` to utilize the organization version cache when retrieving organization version, and to clear the cache when organization data changes. 

**DAO and service layer changes:**

* Added a new method `getOrganizationVersion` to the `OrganizationManagementDAO` interface, and provided implementations in both cache-backed and JDBC-based DAOs. This method now returns an `Optional<String>` and uses the cache where appropriate. 
* Refactored `OrganizationManagerImpl#getOrganizationVersion` to use the new DAO method and handle sub-organization logic, simplifying the code and improving error handling.

**Configuration updates:**

* Added cache configuration for `OrganizationVersionCache` to both `organization-mgt.xml` and its Jinja template, enabling and configuring the cache in the deployment. 

**Error handling improvements:**

* Introduced a new error code and message for failures when retrieving organization version, improving diagnostics and maintainability.

**SQL and import updates:**

* Added a new SQL constant `GET_ORGANIZATION_VERSION` for querying organization version from the database, and updated imports in relevant files. 

## Related issue
- https://github.com/wso2/product-is/issues/25760