### PR TITLE
Fix validation for creator.id in organization patch API

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -565,7 +565,36 @@ public class OrganizationManagerImpl implements OrganizationManager {
     @Override
     public Organization patchOrganization(String organizationId, List<PatchOperation> patchOperations) throws
             OrganizationManagementException {
+        for (PatchOperation operation : patchOperations) {
 
+            if (StringUtils.isNotEmpty(operation.getPath()) &&
+                    operation.getPath().contains(CREATOR_ID)
+            ) {
+                String creatorId = operation.getValue();
+
+                if (StringUtils.isNotEmpty(creatorId)) {
+
+                    int tenantId =
+                            PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+
+                    try {
+                        AbstractUserStoreManager userStoreManager =
+                                Utils.getUserStoreManager(tenantId);
+
+                        if (!userStoreManager.isExistingUserWithID(creatorId)) {
+                            throw handleClientException(
+                                    ERROR_CODE_ORGANIZATION_OWNER_NOT_EXIST,
+                                    String.valueOf(tenantId));
+                        }
+                    } catch (UserStoreException e) {
+                        throw handleServerException(
+                                ERROR_CODE_ERROR_VALIDATING_ORGANIZATION_OWNER,
+                                e,
+                                organizationId);
+                    }
+                }
+            }
+        }
         if (StringUtils.isBlank(organizationId)) {
             throw handleClientException(ERROR_CODE_ORGANIZATION_ID_UNDEFINED);
         }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -565,36 +565,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
     @Override
     public Organization patchOrganization(String organizationId, List<PatchOperation> patchOperations) throws
             OrganizationManagementException {
-        for (PatchOperation operation : patchOperations) {
 
-            if (StringUtils.isNotEmpty(operation.getPath()) &&
-                    operation.getPath().contains(CREATOR_ID)
-            ) {
-                String creatorId = operation.getValue();
-
-                if (StringUtils.isNotEmpty(creatorId)) {
-
-                    int tenantId =
-                            PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
-
-                    try {
-                        AbstractUserStoreManager userStoreManager =
-                                Utils.getUserStoreManager(tenantId);
-
-                        if (!userStoreManager.isExistingUserWithID(creatorId)) {
-                            throw handleClientException(
-                                    ERROR_CODE_ORGANIZATION_OWNER_NOT_EXIST,
-                                    String.valueOf(tenantId));
-                        }
-                    } catch (UserStoreException e) {
-                        throw handleServerException(
-                                ERROR_CODE_ERROR_VALIDATING_ORGANIZATION_OWNER,
-                                e,
-                                organizationId);
-                    }
-                }
-            }
-        }
         if (StringUtils.isBlank(organizationId)) {
             throw handleClientException(ERROR_CODE_ORGANIZATION_ID_UNDEFINED);
         }
@@ -1122,6 +1093,27 @@ public class OrganizationManagerImpl implements OrganizationManager {
             throws OrganizationManagementException {
 
         for (PatchOperation patchOperation : patchOperations) {
+            if (StringUtils.isNotEmpty(patchOperation.getPath()) && patchOperation.getPath().contains(CREATOR_ID)) {
+                String creatorId = patchOperation.getValue();
+
+                if (StringUtils.isNotEmpty(creatorId)) {
+                    int tenantId =
+                            PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                                    .getTenantId();
+                    try {
+                        AbstractUserStoreManager userStoreManager = Utils.getUserStoreManager(tenantId);
+                        if (!userStoreManager.isExistingUserWithID(creatorId)) {
+                            throw handleClientException(
+                                    ERROR_CODE_ORGANIZATION_OWNER_NOT_EXIST,
+                                    String.valueOf(tenantId));
+                        }
+                    } catch (UserStoreException e) {
+                        throw handleServerException(ERROR_CODE_ERROR_VALIDATING_ORGANIZATION_OWNER,
+                                e,
+                                organizationId);
+                    }
+                }
+            }
 
             if (StringUtils.isBlank(patchOperation.getOp())) {
                 throw handleClientException(ERROR_CODE_PATCH_OPERATION_UNDEFINED, organizationId);

--- a/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
@@ -446,6 +446,7 @@ public class OrganizationManagerImplTest {
 
     @Test
     public void testGetOrganizationWithChildren() throws Exception {
+
         Organization organization = organizationManager.getOrganization(ORG1_ID, true, false);
         assertEquals(organization.getName(), ORG1_NAME);
         assertEquals(organization.getParent().getId(), SUPER_ORG_ID);

--- a/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
@@ -89,6 +89,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_PATH_ORG_NAME;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_PATH_ORG_VERSION;
 import static org.wso2.carbon.stratos.common.constants.TenantConstants.ErrorMessage.ERROR_CODE_EXISTING_DOMAIN;
+
 /**
  * Unit tests for OrganizationManagerImpl.
  */

--- a/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
@@ -89,7 +89,9 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_PATH_ORG_NAME;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_PATH_ORG_VERSION;
 import static org.wso2.carbon.stratos.common.constants.TenantConstants.ErrorMessage.ERROR_CODE_EXISTING_DOMAIN;
-
+/**
+ * Unit tests for OrganizationManagerImpl.
+ */
 public class OrganizationManagerImplTest {
 
     private static final String SUPER = "Super";
@@ -443,7 +445,6 @@ public class OrganizationManagerImplTest {
 
     @Test
     public void testGetOrganizationWithChildren() throws Exception {
-
         Organization organization = organizationManager.getOrganization(ORG1_ID, true, false);
         assertEquals(organization.getName(), ORG1_NAME);
         assertEquals(organization.getParent().getId(), SUPER_ORG_ID);

--- a/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/util/TestUtils.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/util/TestUtils.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.mock;
 import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_ID;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.generateUniqueID;
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+
 /**
  * Utility methods used by tests.
  */

--- a/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/util/TestUtils.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/util/TestUtils.java
@@ -47,7 +47,9 @@ import static org.mockito.Mockito.mock;
 import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_ID;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.generateUniqueID;
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
-
+/**
+ * Utility methods used by tests.
+ */
 public class TestUtils {
 
     public static final String DB_NAME = "testOrgMgt_db";


### PR DESCRIPTION
## Purpose

This PR adds validation for `creator.id` in organization patch operations.

Previously, an invalid `creator.id` could be set through the PATCH API without validation. This change validates the incoming `creator.id` against the user store before applying the update, similar to the validation performed during organization creation.

## Related Issue

* #23942
* https://github.com/wso2/product-is/issues/23942

Fixes #23942

## Testing

* Verified that patching with an invalid `creator.id` returns `ORG-60096`.
* Verified that patching with a valid `creator.id` succeeds.
* Verified that invalid values are not persisted.
